### PR TITLE
Fix conversation reload on deployment

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,6 +4,9 @@
   "main": "src/worker.js",
   "assets": {
     "directory": "./dist",
-    "binding": "ASSETS"
+    "binding": "ASSETS",
+    "assetConfig": {
+      "not_found_handling": "single-page-application"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- configure Cloudflare assets to serve `index.html` for unknown paths

This ensures routes like `/1234` return the SPA rather than a 404 in production.

## Testing
- `npm run lint` *(fails: 40 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687d085b248883268af686a93794ce16