### PR TITLE
Fix conversation reload on deployment

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -1,5 +1,5 @@
 export default {
-  async fetch(request, env, ctx) {
+  async fetch(request, env) {
     const url = new URL(request.url);
     
     // Handle CORS preflight requests
@@ -65,64 +65,15 @@ export default {
       }
     }
     
-    // Define static asset extensions
-    const staticAssetExtensions = [
-      '.js', '.css', '.png', '.jpg', '.jpeg', '.gif', '.ico', '.svg', 
-      '.woff', '.woff2', '.ttf', '.eot', '.otf', '.mp4', '.webm', 
-      '.mp3', '.wav', '.pdf', '.zip', '.json', '.xml', '.txt'
-    ];
-    
-    // Check if request is for a static asset
-    const isStaticAsset = staticAssetExtensions.some(ext => 
-      url.pathname.toLowerCase().endsWith(ext)
-    );
-    
-    // Serve static assets directly
-    if (isStaticAsset) {
-      try {
-        const response = await env.ASSETS.fetch(request);
-        
-        // Add appropriate cache headers for static assets
-        const newHeaders = new Headers(response.headers);
-        newHeaders.set('Cache-Control', 'public, max-age=31536000, immutable');
-        
-        return new Response(response.body, {
-          status: response.status,
-          statusText: response.statusText,
-          headers: newHeaders
-        });
-      } catch (e) {
-        console.error('Static asset not found:', url.pathname);
-        return new Response('Asset not found', { status: 404 });
-      }
-    }
-    
-    // Handle SPA routing - serve index.html for all non-asset, non-API requests
+    // For all other requests, serve assets with SPA fallback configured in
+    // wrangler.jsonc. The asset worker will automatically return `index.html`
+    // when a path isn't found.
     try {
-      const indexRequest = new Request(new URL('/index.html', url.origin), request);
-      const indexResponse = await env.ASSETS.fetch(indexRequest);
-      
-      if (!indexResponse.ok) {
-        throw new Error('index.html not found');
-      }
-      
-      return new Response(indexResponse.body, {
-        status: 200,
-        headers: {
-          'Content-Type': 'text/html; charset=utf-8',
-          'Cache-Control': 'no-cache, no-store, must-revalidate',
-          'Pragma': 'no-cache',
-          'Expires': '0'
-        }
-      });
+      const response = await env.ASSETS.fetch(request);
+      return response;
     } catch (e) {
-      console.error('Failed to serve index.html:', e);
-      return new Response('Application not found', { 
-        status: 404,
-        headers: {
-          'Content-Type': 'text/html'
-        }
-      });
+      console.error('Failed to serve asset:', url.pathname, e);
+      return new Response('Application not found', { status: 404 });
     }
   }
 };

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,6 +4,9 @@
   "main": "src/worker.js",
   "assets": {
     "directory": "./dist",
-    "binding": "ASSETS"
+    "binding": "ASSETS",
+    "assetConfig": {
+      "not_found_handling": "single-page-application"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- simplify worker logic to rely on Cloudflare SPA fallback

## Testing
- `npm run lint` *(fails: 41 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687d085b248883268af686a93794ce16