### PR TITLE
Fix conversation reload on deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ coverage
 *.sw?
 
 *.tsbuildinfo
+.wrangler

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,6 +4,7 @@
   "main": "src/worker.js",
   "assets": {
     "directory": "./dist",
-    "binding": "ASSETS"
+    "binding": "ASSETS",
+    "not_found_handling": "single-page-application"
   }
 }


### PR DESCRIPTION
## Summary
- correct asset fallback configuration in `wrangler.jsonc`
- simplify worker to rely on Cloudflare SPA asset handling
- ignore `.wrangler` dev artifacts

## Testing
- `npm run lint` *(fails: 41 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687d085b248883268af686a93794ce16